### PR TITLE
Add macOS (Apple Silicon) llama.cpp runtime support

### DIFF
--- a/llama_binary.py
+++ b/llama_binary.py
@@ -44,12 +44,25 @@ WINDOWS_CUDA_13 = PlatformSpec(
     ),
 )
 
+MACOS_ARM64 = PlatformSpec(
+    key="macos-arm64",
+    cli_executable="llama-cli",
+    asset_patterns=(
+        "llama-*-bin-macos-arm64.tar.gz",
+    ),
+    required_files=(
+        "llama-cli",
+    ),
+)
+
 
 def _platform_spec() -> PlatformSpec:
     system = platform.system().lower()
     machine = platform.machine().lower()
     if system == "windows" and machine in {"amd64", "x86_64"}:
         return WINDOWS_CUDA_13
+    if system == "darwin" and machine in {"arm64", "aarch64"}:
+        return MACOS_ARM64
     raise RuntimeError(
         "Automatic llama.cpp binary download currently supports Windows x64 CUDA 13 only. "
         "Other platforms are intentionally isolated behind the platform mapping for future support."
@@ -189,8 +202,13 @@ def _extract_assets(assets: list[dict], install_dir: Path) -> None:
             archive_path = temp_dir / asset["name"]
             print(f"[LLM Text Processor] Downloading {asset['name']}...")
             _download(asset["browser_download_url"], archive_path)
-            with zipfile.ZipFile(archive_path) as archive:
-                archive.extractall(install_dir)
+            if asset["name"].endswith((".tar.gz", ".tgz")):
+                import tarfile
+                with tarfile.open(archive_path) as archive:
+                    archive.extractall(install_dir)
+            else:
+                with zipfile.ZipFile(archive_path) as archive:
+                    archive.extractall(install_dir)
 
 
 def ensure_llama_cli_paths() -> LlamaCliPaths:

--- a/llama_cli.py
+++ b/llama_cli.py
@@ -219,6 +219,9 @@ def _parse_response(text: str) -> tuple[str, str, str]:
     perf = perf_match.group(0).strip() if perf_match else ""
     content = text[:perf_match.start()] if perf_match else text
     content = content.strip()
+    # drop leaked llama.cpp loading-spinner artifacts (backspaces + \|/- glyphs) that
+    # some macOS builds emit to stderr before the real output
+    content = re.sub(r"^[\s\x00-\x1f|/\\-]+", "", content)
     if not content.startswith(START_THINKING):
         return content, "", perf
 

--- a/llama_cli.py
+++ b/llama_cli.py
@@ -219,9 +219,9 @@ def _parse_response(text: str) -> tuple[str, str, str]:
     perf = perf_match.group(0).strip() if perf_match else ""
     content = text[:perf_match.start()] if perf_match else text
     content = content.strip()
-    # drop leaked llama.cpp loading-spinner artifacts (backspaces + \|/- glyphs) that
-    # some macOS builds emit to stderr before the real output
-    content = re.sub(r"^[\s\x00-\x1f|/\\-]+", "", content)
+    # drop leaked llama.cpp loading-spinner artifacts (typically backspaces + |/\\- spinner glyphs)
+    # that some macOS builds emit to stderr before the real output
+    content = re.sub(r"^(?:\x08+[|/\\-])+(?:\x08+)?", "", content).lstrip()
     if not content.startswith(START_THINKING):
         return content, "", perf
 


### PR DESCRIPTION
Adds macOS (Apple Silicon / arm64) llama.cpp runtime support using official release binaries, mirroring the existing Windows path.

Changes:
- Add a macOS arm64 runtime spec (darwin/arm64) so the node downloads the right llama.cpp build.
- Support `.tar.gz` extraction for the macOS release asset (it ships as a tarball, not a zip).
- Strip llama.cpp loader-spinner control glyphs from CLI output so the parsed response is clean on macOS.

Validation:
- Verified on Apple Silicon (M-series): binary auto-download, Gemma GGUF inference, and clean parsed output.
- `python -m py_compile llama_binary.py llama_cli.py`

Developed with AI assistance; verified on-device on Apple Silicon.
