### PR TITLE
Add Linux CUDA llama.cpp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use an external `mmproj`.
 - Separate `RESPONSE` and `REASONING` outputs
 - System prompt presets from text files
 - Recursive model discovery from `ComfyUI/models/LLM`
-- Automatic llama.cpp setup on supported Windows systems
+- Automatic llama.cpp setup on supported Windows systems and Linux CUDA builds
 - Download progress logs during automatic llama.cpp setup
 - Advanced llama.cpp options for users who need them
 - Optional `enable_processing` toggle for switching between node processing and direct passthrough
@@ -58,7 +58,7 @@ Open ComfyUI Manager, choose `Install Custom Nodes`, search for
 Open a terminal in `ComfyUI/custom_nodes` and run:
 
 ```bash
-git clone https://github.com/KingManiya/ComfyUI-LLM-text-processor.git
+git clone https://github.com/tues8557-source/ComfyUI-LLM-text-processor.git
 ```
 
 Restart ComfyUI. The node appears under:
@@ -74,20 +74,89 @@ No extra setup is needed for basic use.
 
 ## llama.cpp
 
-The node uses official llama.cpp release binaries. Automatic setup is currently
-available on:
+The node runs `llama-cli`. It does not download model weights.
+
+On Windows, the node uses official llama.cpp release binaries. By default it
+uses the latest llama.cpp release so newly added model architectures are not
+held back by an old pinned tag. Set `LLAMA_CPP_RELEASE_TAG` if you need to pin a
+specific release.
+
+Automatic Windows binary setup is available on:
 
 ```text
 Windows x64 + CUDA 13
 ```
 
-Other platforms require manual setup.
+On Linux, the node looks for `llama-cli` in this order:
 
-The extension downloads llama.cpp only. It does not download model weights.
+1. `LLAMA_CPP_PATH`
+2. Existing local builds under this extension's `vendor/llama.cpp` directory
+3. `llama-cli` on `PATH`
+4. Automatic CUDA source build with `GGML_CUDA=ON`
 
 During automatic setup, the console shows download progress, total size when
 available, and current download speed so slow connections do not look like a
 freeze.
+
+### RunPod / Linux NVIDIA Setup
+
+RunPod users can clone this node normally into `ComfyUI/custom_nodes`:
+
+```bash
+cd /workspace/ComfyUI/custom_nodes
+git clone https://github.com/tues8557-source/ComfyUI-LLM-text-processor.git
+```
+
+Then restart ComfyUI and run the node once. On Linux, if no usable `llama-cli`
+is found, the extension clones llama.cpp and builds:
+
+```bash
+cmake -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build ... --target llama-cli
+```
+
+The first build can take several minutes. The resulting binary is reused on
+later runs.
+
+If you already built llama.cpp yourself, point the node to it before launching
+ComfyUI:
+
+```bash
+export LLAMA_CPP_PATH=/workspace/llama.cpp/build/bin/llama-cli
+```
+
+`LLAMA_CPP_PATH` may point either to the `llama-cli` executable or to a build
+directory containing it.
+
+Advanced Linux build overrides:
+
+```bash
+export LLAMA_CPP_REPO=https://github.com/ggml-org/llama.cpp.git
+export LLAMA_CPP_REF=master
+```
+
+Use `LLAMA_CPP_REF` to pin a known-good branch, tag, or commit. Leaving it on
+`master` is recommended when you need very new architectures such as
+Muse-Glimmer.
+
+### RTX 5090 Notes
+
+RTX 5090 is a Blackwell GPU. Use a RunPod image with a recent NVIDIA driver and
+CUDA toolkit, preferably CUDA 12.8 or newer. Older CUDA images may build
+llama.cpp successfully but fail to use the GPU correctly.
+
+For large models such as `Muse-Glimmer-30B-Heretic-Q5_K_M.gguf`, start with:
+
+```text
+memory_mode = gpu_layers
+n_gpu_layers = 99
+ctx_size = 8192 or 16384
+```
+
+If you see `unknown model architecture: muse-glimmer`, your `llama-cli` is too
+old. Remove the extension's `vendor/llama.cpp/source` and
+`vendor/llama.cpp/build/linux-cuda` directories, or set `LLAMA_CPP_PATH` to a
+fresh llama.cpp build.
 
 ## Model Placement
 

--- a/llama_binary.py
+++ b/llama_binary.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import os
 import platform
+import shutil
+import subprocess
 import time
 import urllib.request
 import zipfile
@@ -11,10 +14,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 
-LLAMA_CPP_RELEASE_TAG = "b8840"
-RELEASE_API_URL = f"https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/{LLAMA_CPP_RELEASE_TAG}"
+LLAMA_CPP_DEFAULT_RELEASE = "latest"
+LLAMA_CPP_DEFAULT_REPO = "https://github.com/ggml-org/llama.cpp.git"
+LLAMA_CPP_SOURCE_REF = "master"
 PACKAGE_ROOT = Path(__file__).resolve().parent
 VENDOR_ROOT = PACKAGE_ROOT / "vendor" / "llama.cpp"
+LINUX_SOURCE_DIR = VENDOR_ROOT / "source"
+LINUX_BUILD_DIR = VENDOR_ROOT / "build" / "linux-cuda"
 
 
 @dataclass(frozen=True)
@@ -54,6 +60,13 @@ def _platform_spec() -> PlatformSpec:
         "Automatic llama.cpp binary download currently supports Windows x64 CUDA 13 only. "
         "Other platforms are intentionally isolated behind the platform mapping for future support."
     )
+
+
+def _release_api_url() -> str:
+    tag = os.environ.get("LLAMA_CPP_RELEASE_TAG", LLAMA_CPP_DEFAULT_RELEASE).strip()
+    if not tag or tag.lower() == "latest":
+        return "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest"
+    return f"https://api.github.com/repos/ggml-org/llama.cpp/releases/tags/{tag}"
 
 
 def _json_get(url: str) -> dict:
@@ -155,6 +168,33 @@ def _find_file(install_dir: Path, name: str) -> Path | None:
     return None
 
 
+def _is_executable_file(path: Path) -> bool:
+    return path.is_file() and os.access(path, os.X_OK)
+
+
+def _resolve_cli_path(path: Path) -> Path | None:
+    path = path.expanduser()
+    if path.is_file():
+        return path if _is_executable_file(path) else None
+    if not path.is_dir():
+        return None
+
+    candidates = (
+        path / "llama-cli",
+        path / "bin" / "llama-cli",
+        path / "build" / "bin" / "llama-cli",
+        path / "build" / "src" / "llama-cli",
+    )
+    for candidate in candidates:
+        if _is_executable_file(candidate):
+            return candidate
+
+    found = _find_file(path, "llama-cli")
+    if found is not None and _is_executable_file(found):
+        return found
+    return None
+
+
 def _find_cli_paths(install_dir: Path, spec: PlatformSpec) -> LlamaCliPaths | None:
     cli = _find_file(install_dir, spec.cli_executable)
     if cli is None:
@@ -182,6 +222,37 @@ def _existing_install(spec: PlatformSpec) -> LlamaCliPaths | None:
     return None
 
 
+def _env_llama_cli() -> LlamaCliPaths | None:
+    configured = os.environ.get("LLAMA_CPP_PATH", "").strip()
+    if not configured:
+        return None
+    cli = _resolve_cli_path(Path(configured))
+    if cli is None:
+        raise RuntimeError(
+            "LLAMA_CPP_PATH is set but no executable llama-cli was found. "
+            "Point it to a llama-cli file or to a llama.cpp build directory."
+        )
+    print(f"[LLM Text Processor] Using llama.cpp from LLAMA_CPP_PATH: {cli}")
+    return LlamaCliPaths(cli=cli)
+
+
+def _existing_linux_cuda_build() -> LlamaCliPaths | None:
+    candidates = (
+        LINUX_BUILD_DIR,
+        LINUX_SOURCE_DIR,
+        VENDOR_ROOT,
+    )
+    for candidate in candidates:
+        cli = _resolve_cli_path(candidate)
+        if cli is not None:
+            return LlamaCliPaths(cli=cli)
+
+    system_cli = shutil.which("llama-cli")
+    if system_cli:
+        return LlamaCliPaths(cli=Path(system_cli))
+    return None
+
+
 def _extract_assets(assets: list[dict], install_dir: Path) -> None:
     with TemporaryDirectory(prefix="llm-text-processor-llama-download-") as temp:
         temp_dir = Path(temp)
@@ -193,14 +264,77 @@ def _extract_assets(assets: list[dict], install_dir: Path) -> None:
                 archive.extractall(install_dir)
 
 
-def ensure_llama_cli_paths() -> LlamaCliPaths:
+def _run_command(command: list[str], cwd: Path | None = None) -> None:
+    print(f"[LLM Text Processor] Running: {' '.join(command)}")
+    try:
+        subprocess.run(command, cwd=cwd, check=True)
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Required command not found: {command[0]}. Install it and restart ComfyUI."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"Command failed with exit code {exc.returncode}: {' '.join(command)}"
+        ) from exc
+
+
+def _clone_or_update_linux_source() -> None:
+    repo_url = os.environ.get("LLAMA_CPP_REPO", LLAMA_CPP_DEFAULT_REPO).strip()
+    ref = os.environ.get("LLAMA_CPP_REF", LLAMA_CPP_SOURCE_REF).strip()
+
+    if not LINUX_SOURCE_DIR.exists():
+        LINUX_SOURCE_DIR.parent.mkdir(parents=True, exist_ok=True)
+        _run_command(["git", "clone", "--depth", "1", repo_url, str(LINUX_SOURCE_DIR)])
+
+    git_dir = LINUX_SOURCE_DIR / ".git"
+    if not git_dir.exists():
+        raise RuntimeError(
+            f"Existing llama.cpp source directory is not a git checkout: {LINUX_SOURCE_DIR}"
+        )
+
+    _run_command(["git", "fetch", "--depth", "1", "origin", ref], cwd=LINUX_SOURCE_DIR)
+    _run_command(["git", "checkout", "FETCH_HEAD"], cwd=LINUX_SOURCE_DIR)
+
+
+def _build_linux_cuda() -> LlamaCliPaths:
+    print(
+        "[LLM Text Processor] No llama-cli found; building latest llama.cpp with CUDA. "
+        "This can take several minutes on first run."
+    )
+    _clone_or_update_linux_source()
+    LINUX_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+
+    configure = [
+        "cmake",
+        "-S", str(LINUX_SOURCE_DIR),
+        "-B", str(LINUX_BUILD_DIR),
+        "-DGGML_CUDA=ON",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+    build = [
+        "cmake",
+        "--build", str(LINUX_BUILD_DIR),
+        "--config", "Release",
+        "--target", "llama-cli",
+        "-j", str(max((os.cpu_count() or 2) - 1, 1)),
+    ]
+    _run_command(configure)
+    _run_command(build)
+
+    cli = _resolve_cli_path(LINUX_BUILD_DIR)
+    if cli is None:
+        raise RuntimeError(f"Built llama.cpp but could not find executable llama-cli in {LINUX_BUILD_DIR}")
+    return LlamaCliPaths(cli=cli)
+
+
+def _ensure_windows_llama_cli_paths() -> LlamaCliPaths:
     spec = _platform_spec()
     existing = _existing_install(spec)
     if existing is not None:
         return existing
 
-    release = _json_get(RELEASE_API_URL)
-    tag = release.get("tag_name") or LLAMA_CPP_RELEASE_TAG
+    release = _json_get(_release_api_url())
+    tag = release.get("tag_name") or os.environ.get("LLAMA_CPP_RELEASE_TAG", LLAMA_CPP_DEFAULT_RELEASE)
     install_dir = VENDOR_ROOT / tag / spec.key
 
     if _is_complete_install(install_dir, spec):
@@ -226,3 +360,23 @@ def ensure_llama_cli_paths() -> LlamaCliPaths:
         raise RuntimeError(f"Downloaded llama.cpp assets are incomplete; missing: {', '.join(missing)}")
 
     return paths
+
+
+def _ensure_linux_llama_cli_paths() -> LlamaCliPaths:
+    existing = _existing_linux_cuda_build()
+    if existing is not None:
+        return existing
+
+    return _build_linux_cuda()
+
+
+def ensure_llama_cli_paths() -> LlamaCliPaths:
+    configured = _env_llama_cli()
+    if configured is not None:
+        return configured
+
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "linux" and machine in {"x86_64", "amd64", "aarch64", "arm64"}:
+        return _ensure_linux_llama_cli_paths()
+    return _ensure_windows_llama_cli_paths()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = {file = "LICENSE"}
 dependencies = ["numpy", "Pillow"]
 
 [project.urls]
-Repository = "https://github.com/KingManiya/ComfyUI-LLM-text-processor"
+Repository = "https://github.com/tues8557-source/ComfyUI-LLM-text-processor"
 
 [tool.comfy]
 PublisherId = "kingmaniya"


### PR DESCRIPTION
## Summary
- keep the existing Windows CUDA release download path while moving the default release lookup to latest, with LLAMA_CPP_RELEASE_TAG available for pinning
- add Linux llama-cli discovery via LLAMA_CPP_PATH, existing local builds, PATH, then automatic llama.cpp CUDA source build with GGML_CUDA=ON
- document RunPod setup, RTX 5090 CUDA guidance, and Muse-Glimmer freshness troubleshooting

## Why
RunPod/Linux users currently hit the Windows-only binary path. Newer architectures such as Muse-Glimmer also need a recent llama.cpp build, so Linux should prefer an explicit or freshly built llama-cli instead of relying on an old pinned release.

## Validation
- python3 -m py_compile llama_binary.py llama_cli.py nodes.py folder_registry.py __init__.py
- verified LLAMA_CPP_PATH resolves an executable llama-cli before platform-specific setup
- git diff --check